### PR TITLE
Built-in EventEmitter polyfill into Waypoint SDK

### DIFF
--- a/packages/waypoint/package.json
+++ b/packages/waypoint/package.json
@@ -44,12 +44,10 @@
     "prettier": "3.2.5",
     "rollup": "4.14.1",
     "rollup-plugin-peer-deps-external": "2.2.4",
+    "rollup-plugin-polyfill-node": "0.13.0",
     "rollup-plugin-typescript2": "0.36.0",
     "tslib": "2.6.2",
     "typescript": "5.4.5",
     "viem": "2.9.2"
-  },
-  "dependencies": {
-    "rollup-plugin-polyfill-node": "^0.13.0"
   }
 }

--- a/packages/waypoint/package.json
+++ b/packages/waypoint/package.json
@@ -46,8 +46,10 @@
     "rollup-plugin-peer-deps-external": "2.2.4",
     "rollup-plugin-typescript2": "0.36.0",
     "tslib": "2.6.2",
-    "viem": "2.9.2",
-    "typescript": "5.4.5"
+    "typescript": "5.4.5",
+    "viem": "2.9.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "rollup-plugin-polyfill-node": "^0.13.0"
+  }
 }

--- a/packages/waypoint/rollup.config.mjs
+++ b/packages/waypoint/rollup.config.mjs
@@ -5,6 +5,7 @@ import fsExtra from "fs-extra"
 import path, { dirname } from "path"
 import { defineConfig } from "rollup"
 import peerDepsExternal from "rollup-plugin-peer-deps-external"
+import nodePolyfills from "rollup-plugin-polyfill-node"
 import typescript from "rollup-plugin-typescript2"
 import { fileURLToPath } from "url"
 
@@ -53,6 +54,7 @@ const mainConfig = defineConfig({
     nodeResolve({
       preferBuiltins: true,
     }),
+    nodePolyfills(),
     commonjs(),
     typescript({
       useTsconfigDeclarationDir: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,10 +242,6 @@ importers:
         version: 8.56.10
 
   packages/waypoint:
-    dependencies:
-      rollup-plugin-polyfill-node:
-        specifier: ^0.13.0
-        version: 0.13.0(rollup@4.14.1)
     devDependencies:
       '@babel/preset-env':
         specifier: 7.24.4
@@ -280,6 +276,9 @@ importers:
       rollup-plugin-peer-deps-external:
         specifier: 2.2.4
         version: 2.2.4(rollup@4.14.1)
+      rollup-plugin-polyfill-node:
+        specifier: 0.13.0
+        version: 0.13.0(rollup@4.14.1)
       rollup-plugin-typescript2:
         specifier: 0.36.0
         version: 0.36.0(rollup@4.14.1)(typescript@5.4.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,10 @@ importers:
         version: 8.56.10
 
   packages/waypoint:
+    dependencies:
+      rollup-plugin-polyfill-node:
+        specifier: ^0.13.0
+        version: 0.13.0(rollup@4.14.1)
     devDependencies:
       '@babel/preset-env':
         specifier: 7.24.4
@@ -1762,6 +1766,15 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-inject@5.0.5':
+    resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -4636,6 +4649,11 @@ packages:
     peerDependencies:
       rollup: '*'
 
+  rollup-plugin-polyfill-node@0.13.0:
+    resolution: {integrity: sha512-FYEvpCaD5jGtyBuBFcQImEGmTxDTPbiHjJdrYIp+mFIwgXiXabxvKUK7ZT9P31ozu2Tqm9llYQMRWsfvTMTAOw==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
+
   rollup-plugin-typescript2@0.36.0:
     resolution: {integrity: sha512-NB2CSQDxSe9+Oe2ahZbf+B4bh7pHwjV5L+RSYpCu7Q5ROuN94F9b6ioWwKfz3ueL3KTtmX4o2MUH2cgHDIEUsw==}
     peerDependencies:
@@ -7138,6 +7156,14 @@ snapshots:
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
+      magic-string: 0.30.10
+    optionalDependencies:
+      rollup: 4.14.1
+
+  '@rollup/plugin-inject@5.0.5(rollup@4.14.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.14.1)
+      estree-walker: 2.0.2
       magic-string: 0.30.10
     optionalDependencies:
       rollup: 4.14.1
@@ -10599,6 +10625,11 @@ snapshots:
 
   rollup-plugin-peer-deps-external@2.2.4(rollup@4.14.1):
     dependencies:
+      rollup: 4.14.1
+
+  rollup-plugin-polyfill-node@0.13.0(rollup@4.14.1):
+    dependencies:
+      '@rollup/plugin-inject': 5.0.5(rollup@4.14.1)
       rollup: 4.14.1
 
   rollup-plugin-typescript2@0.36.0(rollup@4.14.1)(typescript@5.4.5):


### PR DESCRIPTION
Bundle size before: 81.26KB
Bundle size after: 94.07KB

