### PR TITLE
fix: monitor window closing

### DIFF
--- a/packages/waypoint/src/core/communicate.ts
+++ b/packages/waypoint/src/core/communicate.ts
@@ -91,8 +91,9 @@ export class CommunicateHelper {
 
     const intervalId = setInterval(() => {
       const intervalHandler = this.pendingIntervals.get(requestId)
+      const responseHandler = this.pendingRequests.get(requestId)
 
-      if (window?.closed && intervalHandler) {
+      if (window?.closed && intervalHandler && responseHandler) {
         this.handleResponse({
           state: requestId,
           type: "fail",


### PR DESCRIPTION
- only send a response (user reject  = window-close ) when the request has not been completed.